### PR TITLE
Fix for SequencedGenome infocard error

### DIFF
--- a/Source/QEE/Logic/HediffInfo.cs
+++ b/Source/QEE/Logic/HediffInfo.cs
@@ -69,7 +69,7 @@ public class HediffInfo : IExposable, IEquatable<HediffInfo>
         builder.AppendLine("QE_GenomeSequencerDescription_Hediffs".Translate());
 
         //sort hediffs in alphabetical order
-        var ordered = hediffsNonNull.OrderBy(h => h.def.LabelCap);
+        var ordered = hediffsNonNull.OrderBy(h => h.def.LabelCap.RawText);
 
         //loop through hediffs and add line to StringBuilder for each
         foreach (var h in ordered)


### PR DESCRIPTION
When scanned with a Genome Sequencer, hediffs from Evolved Organs Redux (and potentially others) cause infocard errors when trying to view the produced SequencedGenome.

In the code, the OrderBy operation fails to sort the affected hediffs - I suspect this is due to the use of colour or other formatting in the label text. Forcing the sort operation to use RawText fixes the problem and allows the infocard to render properly.