### PR TITLE
varies fixes (biotech genome, disabled skills)

### DIFF
--- a/Source/QEE/Compatibility/SpawnThoseGenes_Patch.cs
+++ b/Source/QEE/Compatibility/SpawnThoseGenes_Patch.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using HarmonyLib;
+using RimWorld;
+using Verse;
+
+namespace QEthics.Compatibility
+{
+    internal static class SpawnThoseGenes_Patch
+    {
+        public static bool ShouldPatch()
+        {
+            return LoadedModManager.RunningMods.Any(mod => mod.Name.Contains("SpawnThoseGenes"));
+        }
+
+        public static void Patch(Harmony harmony)
+        {
+            Type maybeMainClass = AccessTools.TypeByName("SpawnThoseGenes.SpawnThoseGenesMod");
+            if (maybeMainClass == null) return;
+            var method = maybeMainClass.GetMethod("PostfixGenerator", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static, null, [typeof(Pawn), typeof(XenotypeDef), typeof(PawnGenerationRequest)], null);
+            if (method == null) return;
+            harmony.Patch(method, new HarmonyMethod(MuteExtraGenesSpawning));
+        }
+
+        static bool MuteExtraGenesSpawning(Pawn pawn, XenotypeDef xenotype, PawnGenerationRequest request)
+        {
+            return !GenomeUtility.CloningInProgress;
+        } 
+    }
+}

--- a/Source/QEE/HarmonyPatches.cs
+++ b/Source/QEE/HarmonyPatches.cs
@@ -16,6 +16,10 @@ public static class HarmonyPatches
         //HarmonyInstance.DEBUG = true;
 
         harmony.PatchAll(Assembly.GetExecutingAssembly());
+        if (Compatibility.SpawnThoseGenes_Patch.ShouldPatch())
+        {
+            Compatibility.SpawnThoseGenes_Patch.Patch(harmony);
+        }
     }
 }
 

--- a/Source/QEE/Things/Building_PawnVatGrower.cs
+++ b/Source/QEE/Things/Building_PawnVatGrower.cs
@@ -370,6 +370,8 @@ public class Building_PawnVatGrower : Building_GrowerBase, IMaintainableGrower
                 {
                     tempPawn.needs?.mood?.thoughts?.memories?.TryGainMemory(QEThoughtDefOf.QE_VatGrownCloneConfusion);
                 }
+                // request recalculating disabled work type
+                tempPawn.Notify_DisabledWorkTypesChanged();
 
                 //Adds history event used by precepts, done hear since it's easier than patching it just for ideology
                 Find.HistoryEventsManager.RecordEvent(new HistoryEvent(QEHistoryDefOf.PawnCloned));

--- a/Source/QEE/Things/GenomeSequence.cs
+++ b/Source/QEE/Things/GenomeSequence.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using RimWorld;
@@ -27,7 +27,8 @@ public class GenomeSequence : ThingWithComps
     public TattooDef faceTattoo;
     public Color? favoriteColor;
     public Gender gender = Gender.None;
-    public List<string> genes;
+    public List<Gene> endogenes;
+    public List<Gene> xenogenes;
     public HairDef hair;
     public Color hairColor = new Color(0.0f, 0.0f, 0.0f);
     public Color hairColorSecond;
@@ -108,6 +109,8 @@ public class GenomeSequence : ThingWithComps
             Scribe_Defs.Look(ref bodyTattoo, "bodyTattoo");
             Scribe_Defs.Look(ref xenotype, "xenotype");
             Scribe_Collections.Look(ref genes, "genes", LookMode.Value);
+            Scribe_Collections.Look(ref endogenes, "genes", LookMode.Value);
+            Scribe_Collections.Look(ref xenogenes, "genes", LookMode.Value);
             Scribe_Values.Look(ref favoriteColor, "favoriteColor");
 
             //Humanoid values that could be null in save file go here
@@ -191,8 +194,10 @@ public class GenomeSequence : ThingWithComps
             mouthType == otherGenome.mouthType &&
             skinType == otherGenome.skinType &&
             xenotype == otherGenome.xenotype &&
-            (genes == null && otherGenome.genes == null || genes != null && otherGenome.genes != null &&
-                genes.OrderBy(h => h).SequenceEqual(otherGenome.genes.OrderBy(h => h))) &&
+            (endogenes == null && otherGenome.endogenes == null || endogenes != null && otherGenome.endogenes != null &&
+                endogenes.OrderBy(h => h).SequenceEqual(otherGenome.endogenes.OrderBy(h => h))) &&
+            (xenogenes == null && otherGenome.xenogenes == null || xenogenes != null && otherGenome.xenogenes != null &&
+                xenogenes.OrderBy(h => h).SequenceEqual(otherGenome.xenogenes.OrderBy(h => h))) &&
             crownTypeAlien == otherGenome.crownTypeAlien &&
             (hair != null && otherGenome.hair != null && hair.ToString() == otherGenome.hair.ToString()
              || hair == null && otherGenome.hair == null) &&
@@ -245,7 +250,8 @@ public class GenomeSequence : ThingWithComps
         splitThingStack.faceTattoo = faceTattoo;
         splitThingStack.bodyTattoo = bodyTattoo;
         splitThingStack.xenotype = xenotype;
-        splitThingStack.genes = genes;
+        splitThingStack.xenogenes = xenogenes;
+        splitThingStack.endogenes = endogenes;
         splitThingStack.spawnShambler = spawnShambler;
         foreach (var traitEntry in traits)
         {

--- a/Source/QEE/Things/GenomeSequence.cs
+++ b/Source/QEE/Things/GenomeSequence.cs
@@ -35,8 +35,9 @@ public class GenomeSequence : ThingWithComps
     public HairDef hair;
     public Color hairColor = new Color(0.0f, 0.0f, 0.0f);
     public Color hairColorSecond;
-    public string xenotypeName;
-    public XenotypeIconDef xenotypeIcon; //adding these allow for player-made xenotypes to be properly cloned
+    public XenotypeDef xenotype;
+    public bool hybrid;
+    public CustomXenotype customXenotype; //adding these allow for player-made xenotypes to be properly cloned
 
     // Facial Animation compatibility
     public string headType;
@@ -61,14 +62,13 @@ public class GenomeSequence : ThingWithComps
     public Color skinColorSecond;
 
     public float skinMelanin;
+    public Color? skinColorOverride;
     public string skinType;
 
     //Relevant for all genomes.
     public string sourceName = "QE_BlankGenomeTemplateName".Translate().RawText ?? "Do Not Use This";
     public bool spawnShambler;
     public List<ExposedTraitEntry> traits = [];
-    public XenotypeDef xenotype;
-    public bool hybrid;
 
     public override string LabelNoCount
     {
@@ -107,6 +107,7 @@ public class GenomeSequence : ThingWithComps
         {
             Scribe_Defs.Look(ref bodyType, "bodyType");
             Scribe_Values.Look(ref hairColor, "hairColor");
+            Scribe_Values.Look(ref skinColorOverride, "skinColorOverride");
             Scribe_Values.Look(ref skinMelanin, "skinMelanin");
             Scribe_Collections.Look(ref traits, "traits", LookMode.Deep);
             Scribe_Defs.Look(ref hair, "hair");
@@ -114,6 +115,7 @@ public class GenomeSequence : ThingWithComps
             Scribe_Defs.Look(ref faceTattoo, "faceTattoo");
             Scribe_Defs.Look(ref bodyTattoo, "bodyTattoo");
             Scribe_Defs.Look(ref xenotype, "xenotype");
+            Scribe_Deep.Look(ref customXenotype, "customXenotype");
             Scribe_Values.Look(ref hybrid, "hybrid");
             Scribe_Collections.Look(ref endogenes, "endogenes", LookMode.Def);
             Scribe_Collections.Look(ref xenogenes, "xenogenes", LookMode.Def);
@@ -208,6 +210,7 @@ public class GenomeSequence : ThingWithComps
             beard == otherGenome.beard &&
             faceTattoo == otherGenome.faceTattoo &&
             bodyTattoo == otherGenome.bodyTattoo &&
+            skinColorOverride == otherGenome.skinColorOverride &&
             skinColor == otherGenome.skinColor &&
             skinColorSecond == otherGenome.skinColorSecond &&
             hairColorSecond == otherGenome.hairColorSecond &&
@@ -221,8 +224,7 @@ public class GenomeSequence : ThingWithComps
             skinType == otherGenome.skinType &&
             xenotype == otherGenome.xenotype &&
             hybrid == otherGenome.hybrid &&
-            xenotypeName == otherGenome.xenotypeName &&
-            xenotypeIcon == otherGenome.xenotypeIcon &&
+            customXenotype == otherGenome.customXenotype &&
             (endogenes == null && otherGenome.endogenes == null || endogenes != null && otherGenome.endogenes != null &&
                 endogenes.OrderBy(h => h.defName).SequenceEqual(otherGenome.endogenes.OrderBy(h => h.defName))) &&
             (xenogenes == null && otherGenome.xenogenes == null || xenogenes != null && otherGenome.xenogenes != null &&
@@ -272,6 +274,7 @@ public class GenomeSequence : ThingWithComps
         splitThingStack.bodyType = bodyType;
         splitThingStack.crownType = crownType;
         splitThingStack.hairColor = hairColor;
+        splitThingStack.skinColorOverride = skinColorOverride;
         splitThingStack.skinMelanin = skinMelanin;
         splitThingStack.hair = hair;
         splitThingStack.beard = beard;
@@ -280,8 +283,7 @@ public class GenomeSequence : ThingWithComps
         splitThingStack.bodyTattoo = bodyTattoo;
         splitThingStack.hybrid = hybrid;
         splitThingStack.xenotype = xenotype;
-        splitThingStack.xenotypeName = xenotypeName;
-        splitThingStack.xenotypeIcon = xenotypeIcon;
+        splitThingStack.customXenotype = customXenotype;
         splitThingStack.xenogenes = xenogenes;
         splitThingStack.endogenes = endogenes;
         splitThingStack.spawnShambler = spawnShambler;

--- a/Source/QEE/Things/GenomeSequence.cs
+++ b/Source/QEE/Things/GenomeSequence.cs
@@ -28,13 +28,17 @@ public class GenomeSequence : ThingWithComps
     public TattooDef faceTattoo;
     public Color? favoriteColor;
     public Gender gender = Gender.None;
+    public HairDef hair;
+    public Color hairColor = new Color(0.0f, 0.0f, 0.0f);
+    public Color hairColorSecond;
+
+    //Relevant for all genomes.
     [Obsolete("For mitigation only. Use endogenes and xenogenes instead.")]
     public List<string> genes;
     public List<GeneDef> endogenes;
     public List<GeneDef> xenogenes;
-    public HairDef hair;
-    public Color hairColor = new Color(0.0f, 0.0f, 0.0f);
-    public Color hairColorSecond;
+    public List<GeneDef> activeRandomlyChosenEndogenes;
+    public List<GeneDef> activeRandomlyChosenXenogenes;
     public XenotypeDef xenotype;
     public bool hybrid;
     public CustomXenotype customXenotype; //adding these allow for player-made xenotypes to be properly cloned
@@ -62,10 +66,10 @@ public class GenomeSequence : ThingWithComps
     public Color skinColorSecond;
 
     public float skinMelanin;
+    public Color? skinColorBase;
     public Color? skinColorOverride;
     public string skinType;
 
-    //Relevant for all genomes.
     public string sourceName = "QE_BlankGenomeTemplateName".Translate().RawText ?? "Do Not Use This";
     public bool spawnShambler;
     public List<ExposedTraitEntry> traits = [];
@@ -107,6 +111,7 @@ public class GenomeSequence : ThingWithComps
         {
             Scribe_Defs.Look(ref bodyType, "bodyType");
             Scribe_Values.Look(ref hairColor, "hairColor");
+            Scribe_Values.Look(ref skinColorBase, "skinColorBase");
             Scribe_Values.Look(ref skinColorOverride, "skinColorOverride");
             Scribe_Values.Look(ref skinMelanin, "skinMelanin");
             Scribe_Collections.Look(ref traits, "traits", LookMode.Deep);
@@ -119,6 +124,8 @@ public class GenomeSequence : ThingWithComps
             Scribe_Values.Look(ref hybrid, "hybrid");
             Scribe_Collections.Look(ref endogenes, "endogenes", LookMode.Def);
             Scribe_Collections.Look(ref xenogenes, "xenogenes", LookMode.Def);
+            Scribe_Collections.Look(ref activeRandomlyChosenEndogenes, "activeRandomlyChosenEndogenes", LookMode.Def);
+            Scribe_Collections.Look(ref activeRandomlyChosenXenogenes, "activeRandomlyChosenXenogenes", LookMode.Def);
             Scribe_Values.Look(ref favoriteColor, "favoriteColor");
 
             // ensure we only load the old 'genes' field, but not dumping it again
@@ -205,12 +212,13 @@ public class GenomeSequence : ThingWithComps
             crownType == otherGenome.crownType &&
             hairColor == otherGenome.hairColor &&
             skinMelanin == otherGenome.skinMelanin &&
+            skinColorBase == otherGenome.skinColorBase &&
+            skinColorOverride == otherGenome.skinColorOverride &&
             isAlien == otherGenome.isAlien &&
             favoriteColor == otherGenome.favoriteColor &&
             beard == otherGenome.beard &&
             faceTattoo == otherGenome.faceTattoo &&
             bodyTattoo == otherGenome.bodyTattoo &&
-            skinColorOverride == otherGenome.skinColorOverride &&
             skinColor == otherGenome.skinColor &&
             skinColorSecond == otherGenome.skinColorSecond &&
             hairColorSecond == otherGenome.hairColorSecond &&
@@ -229,6 +237,12 @@ public class GenomeSequence : ThingWithComps
                 endogenes.OrderBy(h => h.defName).SequenceEqual(otherGenome.endogenes.OrderBy(h => h.defName))) &&
             (xenogenes == null && otherGenome.xenogenes == null || xenogenes != null && otherGenome.xenogenes != null &&
                 xenogenes.OrderBy(h => h.defName).SequenceEqual(otherGenome.xenogenes.OrderBy(h => h.defName))) &&
+            (activeRandomlyChosenEndogenes == null && otherGenome.activeRandomlyChosenEndogenes == null
+            || activeRandomlyChosenEndogenes != null && otherGenome.activeRandomlyChosenEndogenes != null &&
+                activeRandomlyChosenEndogenes.OrderBy(h => h.defName).SequenceEqual(otherGenome.activeRandomlyChosenEndogenes.OrderBy(h => h.defName))) &&
+            (activeRandomlyChosenXenogenes == null && otherGenome.activeRandomlyChosenXenogenes == null
+            || activeRandomlyChosenXenogenes != null && otherGenome.activeRandomlyChosenXenogenes != null &&
+                activeRandomlyChosenXenogenes.OrderBy(h => h.defName).SequenceEqual(otherGenome.activeRandomlyChosenXenogenes.OrderBy(h => h.defName))) &&
             crownTypeAlien == otherGenome.crownTypeAlien &&
             (hair != null && otherGenome.hair != null && hair.ToString() == otherGenome.hair.ToString()
              || hair == null && otherGenome.hair == null) &&
@@ -274,6 +288,7 @@ public class GenomeSequence : ThingWithComps
         splitThingStack.bodyType = bodyType;
         splitThingStack.crownType = crownType;
         splitThingStack.hairColor = hairColor;
+        splitThingStack.skinColorBase = skinColorBase;
         splitThingStack.skinColorOverride = skinColorOverride;
         splitThingStack.skinMelanin = skinMelanin;
         splitThingStack.hair = hair;
@@ -286,6 +301,8 @@ public class GenomeSequence : ThingWithComps
         splitThingStack.customXenotype = customXenotype;
         splitThingStack.xenogenes = xenogenes;
         splitThingStack.endogenes = endogenes;
+        splitThingStack.activeRandomlyChosenEndogenes = activeRandomlyChosenEndogenes;
+        splitThingStack.activeRandomlyChosenXenogenes = activeRandomlyChosenXenogenes;
         splitThingStack.spawnShambler = spawnShambler;
         foreach (var traitEntry in traits)
         {

--- a/Source/QEE/Things/GenomeSequence.cs
+++ b/Source/QEE/Things/GenomeSequence.cs
@@ -108,8 +108,8 @@ public class GenomeSequence : ThingWithComps
             Scribe_Defs.Look(ref faceTattoo, "faceTattoo");
             Scribe_Defs.Look(ref bodyTattoo, "bodyTattoo");
             Scribe_Defs.Look(ref xenotype, "xenotype");
-            Scribe_Collections.Look(ref endogenes, "endogenes", LookMode.Value);
-            Scribe_Collections.Look(ref xenogenes, "xenogenes", LookMode.Value);
+            Scribe_Collections.Look(ref endogenes, "endogenes", LookMode.Reference);
+            Scribe_Collections.Look(ref xenogenes, "xenogenes", LookMode.Reference);
             Scribe_Values.Look(ref favoriteColor, "favoriteColor");
 
             //Humanoid values that could be null in save file go here

--- a/Source/QEE/Things/GenomeSequence.cs
+++ b/Source/QEE/Things/GenomeSequence.cs
@@ -108,9 +108,8 @@ public class GenomeSequence : ThingWithComps
             Scribe_Defs.Look(ref faceTattoo, "faceTattoo");
             Scribe_Defs.Look(ref bodyTattoo, "bodyTattoo");
             Scribe_Defs.Look(ref xenotype, "xenotype");
-            Scribe_Collections.Look(ref genes, "genes", LookMode.Value);
-            Scribe_Collections.Look(ref endogenes, "genes", LookMode.Value);
-            Scribe_Collections.Look(ref xenogenes, "genes", LookMode.Value);
+            Scribe_Collections.Look(ref endogenes, "endogenes", LookMode.Value);
+            Scribe_Collections.Look(ref xenogenes, "xenogenes", LookMode.Value);
             Scribe_Values.Look(ref favoriteColor, "favoriteColor");
 
             //Humanoid values that could be null in save file go here
@@ -195,9 +194,9 @@ public class GenomeSequence : ThingWithComps
             skinType == otherGenome.skinType &&
             xenotype == otherGenome.xenotype &&
             (endogenes == null && otherGenome.endogenes == null || endogenes != null && otherGenome.endogenes != null &&
-                endogenes.OrderBy(h => h).SequenceEqual(otherGenome.endogenes.OrderBy(h => h))) &&
+                endogenes.OrderBy(h => h.def.defName).SequenceEqual(otherGenome.endogenes.OrderBy(h => h.def.defName))) &&
             (xenogenes == null && otherGenome.xenogenes == null || xenogenes != null && otherGenome.xenogenes != null &&
-                xenogenes.OrderBy(h => h).SequenceEqual(otherGenome.xenogenes.OrderBy(h => h))) &&
+                xenogenes.OrderBy(h => h.def.defName).SequenceEqual(otherGenome.xenogenes.OrderBy(h => h.def.defName))) &&
             crownTypeAlien == otherGenome.crownTypeAlien &&
             (hair != null && otherGenome.hair != null && hair.ToString() == otherGenome.hair.ToString()
              || hair == null && otherGenome.hair == null) &&

--- a/Source/QEE/Things/GenomeSequence.cs
+++ b/Source/QEE/Things/GenomeSequence.cs
@@ -32,6 +32,8 @@ public class GenomeSequence : ThingWithComps
     public HairDef hair;
     public Color hairColor = new Color(0.0f, 0.0f, 0.0f);
     public Color hairColorSecond;
+    public string xenotypeName;
+    public XenotypeIconDef xenotypeIcon; //adding these allow for player-made xenotypes to be properly cloned
 
     // Facial Animation compatibility
     public string headType;
@@ -193,6 +195,8 @@ public class GenomeSequence : ThingWithComps
             mouthType == otherGenome.mouthType &&
             skinType == otherGenome.skinType &&
             xenotype == otherGenome.xenotype &&
+            xenotypeName == otherGenome.xenotypeName &&
+            xenotypeIcon == otherGenome.xenotypeIcon &&
             (endogenes == null && otherGenome.endogenes == null || endogenes != null && otherGenome.endogenes != null &&
                 endogenes.OrderBy(h => h.def.defName).SequenceEqual(otherGenome.endogenes.OrderBy(h => h.def.defName))) &&
             (xenogenes == null && otherGenome.xenogenes == null || xenogenes != null && otherGenome.xenogenes != null &&

--- a/Source/QEE/Utilities/BrainManipUtility.cs
+++ b/Source/QEE/Utilities/BrainManipUtility.cs
@@ -211,7 +211,7 @@ public static class BrainManipUtility
         if (storyTracker != null)
         {
             //story.childhood = brainScan.backStoryChild;
-            storyTracker.adulthood = brainScan.backStoryAdult;
+            storyTracker.Adulthood = brainScan.backStoryAdult;
         }
 
         //Skills
@@ -223,8 +223,8 @@ public static class BrainManipUtility
                 var pawnSkill = skillTracker.GetSkill(skill.def);
                 pawnSkill.Level = (int)Math.Floor(skill.level * efficency);
                 pawnSkill.passion = skill.passion;
-                pawnSkill.Notify_SkillDisablesChanged();
             }
+            skillTracker.Notify_SkillDisablesChanged();
         }
 
         //Training

--- a/Source/QEE/Utilities/GenomeUtility.cs
+++ b/Source/QEE/Utilities/GenomeUtility.cs
@@ -192,14 +192,10 @@ public static class GenomeUtility
                 storyTracker.headType = genomeSequence.crownType;
             }
 
+            storyTracker.hairColor = genomeSequence.hairColor;
             storyTracker.hairDef = genomeSequence.hair ?? storyTracker.hairDef;
             storyTracker.favoriteColor = genomeSequence.favoriteColor;
-
-            if (genomeSequence.endogenes?.Any() == false) //if they have endogenes, let those decide their colours instead.
-            {
-                storyTracker.hairColor = genomeSequence.hairColor;
-                storyTracker.melanin = genomeSequence.skinMelanin;
-            }
+            storyTracker.melanin = genomeSequence.skinMelanin;
 
             storyTracker.traits.allTraits.Clear();
             QEEMod.TryLog("Setting traits for generated pawn");

--- a/Source/QEE/Utilities/GenomeUtility.cs
+++ b/Source/QEE/Utilities/GenomeUtility.cs
@@ -88,6 +88,8 @@ public static class GenomeUtility
                                                                    //change the pawn's xenotype into that of the empty
                                                                    //genomeSequence's, reverting non-baseliner pawns
                                                                    //into baseliners.
+                    genomeSequence.xenotypeName = pawn.genes.xenotypeName;
+                    genomeSequence.xenotypeIcon = pawn.genes.iconDef;
                 }
 
                 //Alien Races compatibility.
@@ -181,7 +183,7 @@ public static class GenomeUtility
             //sanity check to remove possibility of an Undefined crownType
             if (genomeSequence.crownType == null)
             {
-                storyTracker.headType = DefDatabase<HeadTypeDef>.GetNamedSilentFail(pawn.gender == Gender.Female 
+                storyTracker.headType = DefDatabase<HeadTypeDef>.GetNamedSilentFail(pawn.gender == Gender.Female
                     ? "Female_AverageNormal"
                     : "Male_AverageNormal");
             }
@@ -233,6 +235,8 @@ public static class GenomeUtility
             if (genomeSequence.xenotype != null)
             {
                 geneTracker.xenotype = genomeSequence.xenotype;
+                geneTracker.xenotypeName = genomeSequence.xenotypeName;
+                geneTracker.iconDef = genomeSequence.xenotypeIcon;
             }
             //the logic previously used in this block was both flawed and wrong.
             //  geneTracker.AddGene(geneDef, geneDef.endogeneCategory != EndogeneCategory.None);


### PR DESCRIPTION
Note: fixes biotech genome are based on #2. This pull request adds a mitigation code to help moving the old sequence into new one. Huge thanks to them for finding out this issue and make fixes for it!

## Issues to fix
1. When sequencing genome from a pawn, the xenotype will be reverted into baseliner. This also related to genome sequence never actually record xenotype
2. Gene type (endogene/xenogene) of the clone pawn mismatch from the source
3. When clone pawn is pick up from clone vat, most skills are disabled although those skills are not disabled by any backstories, traits, genes, etc.
4. When brain template is applied, the backstory is not updated. _(need checking)_

## Other Changes
1. When an old save with genome sequence is loaded, a mitigation function will be run to move old gene list into more detailed xenogene and endogene list. This function will also tries to guess what xenotype the source pawn should be. It runs as follows:
    1. Scan the world and map to see if the source pawn is still here
    2. If the source pawn is destroyed, set all genes as endogene and finish; otherwise continue the steps
    3. loop over the current genes of the source pawn. assign xeno- or endo- for genes in the genome sequence. The first melanin gene found will always be assigned as endogene, as in vanilla game.
    4. If the xenotype of source pawn is not baseliner, assign it in the genome sequence. Otherwise continue the steps
    5. Calculate the distance of gene set to the gene set in every defined xenotype. The gene set of genome sequence to be compared is based on whether the defined xenotype in inheritable or not. The xenotype with the most similar gene set and within acceptable gene difference will be assigned in the genome sequence.
2. Some state of genome sequence to be assigned is moved to `PawnGenerationRequest` for better compatibility (supposingly).
    - This also introduce a patch on SpawnThoseGenes to mute it from making extra genes.
3. Removing pregenerated hediffs will now utilize `RemoveHediff` method for sanity. This change is made because I want to add some compatibility function to allow other mods to keep their hediff made inside `GeneratePawn` method _(RimJo...\*\*cough\*\*)_, but still this change does goods and no harms.