### PR TITLE
VSE compat, Alpha Implant compat, revamp general compatibility

### DIFF
--- a/1.5/Defs/RecipeDefs/Recipes_BrainScanning.xml
+++ b/1.5/Defs/RecipeDefs/Recipes_BrainScanning.xml
@@ -15,8 +15,8 @@
     <soundWorking>Interact_Research</soundWorking>
     <anesthetize>false</anesthetize>
     <isViolation>true</isViolation>
-    <!--targetsBodyPart>false</targetsBodyPart-->
-    <hideBodyPartNames>true</hideBodyPartNames>
+    <targetsBodyPart>false</targetsBodyPart>
+    <!-- <hideBodyPartNames>true</hideBodyPartNames> -->
     <skillRequirements>
       <Medicine>10</Medicine>
     </skillRequirements>

--- a/1.5/Defs/RecipeDefs/Recipes_GenomeSequence.xml
+++ b/1.5/Defs/RecipeDefs/Recipes_GenomeSequence.xml
@@ -15,8 +15,8 @@
     <soundWorking>Interact_Research</soundWorking>
     <anesthetize>false</anesthetize>
     <isViolation>true</isViolation>
-    <!--targetsBodyPart>false</targetsBodyPart-->
-    <hideBodyPartNames>true</hideBodyPartNames>
+    <targetsBodyPart>false</targetsBodyPart>
+    <!-- <hideBodyPartNames>true</hideBodyPartNames> -->
     <skillRequirements>
       <Medicine>8</Medicine>
     </skillRequirements>

--- a/1.5/Patches/Add_Surgeries.xml
+++ b/1.5/Patches/Add_Surgeries.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+    <Operation Class="PatchOperationFindMod">
+        <!-- Since not forcely adding surgeries to pawns works without the following mods. Only forcely add surgeries if they're present -->
+        <mods>
+            <li>Alpha Implants</li>
+        </mods>
+        <match Class="PatchOperationSequence">
+            <success>Always</success>
+            <operations>
+                <li Class="PatchOperationAdd">
+                    <xpath>/Defs/ThingDef[@Name="AnimalThingBase"]/recipes</xpath>
+                    <value>
+                        
+                        <li>QE_BrainScanning</li>
+                        <li>QE_GenomeSequencing</li>
+                    </value>
+                </li>
+                <li Class="PatchOperationAdd">
+                    <xpath>/Defs/ThingDef[defName="Human"]/recipes</xpath>
+                    <value>
+                        
+                        <li>QE_BrainScanning</li>
+                        <li>QE_GenomeSequencing</li>
+                    </value>
+                </li>
+            </operations>
+        </match>
+	</Operation>
+</Patch>

--- a/Languages/ChineseSimplified/Keyed/QuestionableEthics.xml
+++ b/Languages/ChineseSimplified/Keyed/QuestionableEthics.xml
@@ -120,4 +120,8 @@
   <QE_UseFillingGraphic>可视化成分填充</QE_UseFillingGraphic>
   <QE_UseFillingGraphicTooltip>仍然显示大桶在装满资源，而不是在装满之前显示为空的</QE_UseFillingGraphicTooltip>
   <QE_MessageCloningFailedAnomaly>由于基因组序列异常，克隆工作惨遭失败，{0}生成了一个残缺不全的废卒</QE_MessageCloningFailedAnomaly>
+  <QE_GenomeSequencerRejectExcludedHediffShort>hediff阻止基因组测序</QE_GenomeSequencerRejectExcludedHediffShort>
+  <QE_BrainScanningRejectExcludedHediffShort>hediff阻止大脑扫描</QE_BrainScanningRejectExcludedHediffShort>
+  <QE_TemplatingRejectExcludedRaceShort>无效种族</QE_TemplatingRejectExcludedRaceShort>
+  <QE_BrainScanDescription_Expertises>储存的专业知识</QE_BrainScanDescription_Expertises>
 </LanguageData>

--- a/Languages/English/Keyed/QuestionableEthics.xml
+++ b/Languages/English/Keyed/QuestionableEthics.xml
@@ -137,8 +137,8 @@
   <QE_MessagestapledPawnEnslaved>{0} was enslaved by {1} using a nerve staple</QE_MessagestapledPawnEnslaved>
   <QE_MessageCloningFailedAnomaly>Cloning failed horribly due to an abnormal genome-sequence, {0} spawned as a broken hulk of a pawn</QE_MessageCloningFailedAnomaly>
   <!-- version 1.5.8 Patch -->
-  <QE_GenomeSequencerRejectExcludedHediffShort>hediff excluding genome sequencing</QE_GenomeSequencerRejectExcludedHediffShort>
-  <QE_BrainScanningRejectExcludedHediffShort>hediff excluding brain scan</QE_BrainScanningRejectExcludedHediffShort>
+  <QE_GenomeSequencerRejectExcludedHediffShort>hediffs excluding genome sequencing</QE_GenomeSequencerRejectExcludedHediffShort>
+  <QE_BrainScanningRejectExcludedHediffShort>hediffs excluding brain scanning</QE_BrainScanningRejectExcludedHediffShort>
   <QE_TemplatingRejectExcludedRaceShort>not valid race</QE_TemplatingRejectExcludedRaceShort>
   <QE_BrainScanDescription_Expertises>Stored expertises</QE_BrainScanDescription_Expertises>
 </LanguageData>

--- a/Languages/English/Keyed/QuestionableEthics.xml
+++ b/Languages/English/Keyed/QuestionableEthics.xml
@@ -136,4 +136,8 @@
   <QE_GenomeSequencerDescription_Hediffs>Hediffs</QE_GenomeSequencerDescription_Hediffs>
   <QE_MessagestapledPawnEnslaved>{0} was enslaved by {1} using a nerve staple</QE_MessagestapledPawnEnslaved>
   <QE_MessageCloningFailedAnomaly>Cloning failed horribly due to an abnormal genome-sequence, {0} spawned as a broken hulk of a pawn</QE_MessageCloningFailedAnomaly>
+  <!-- version 1.5.8 Patch -->
+  <QE_GenomeSequencerRejectExcludedHediffShort>hediff excluding genome sequencing</QE_GenomeSequencerRejectExcludedHediffShort>
+  <QE_BrainScanningRejectExcludedHediffShort>hediff excluding brain scan</QE_BrainScanningRejectExcludedHediffShort>
+  <QE_TemplatingRejectExcludedRaceShort>not valid race</QE_TemplatingRejectExcludedRaceShort>
 </LanguageData>

--- a/Languages/English/Keyed/QuestionableEthics.xml
+++ b/Languages/English/Keyed/QuestionableEthics.xml
@@ -140,4 +140,5 @@
   <QE_GenomeSequencerRejectExcludedHediffShort>hediff excluding genome sequencing</QE_GenomeSequencerRejectExcludedHediffShort>
   <QE_BrainScanningRejectExcludedHediffShort>hediff excluding brain scan</QE_BrainScanningRejectExcludedHediffShort>
   <QE_TemplatingRejectExcludedRaceShort>not valid race</QE_TemplatingRejectExcludedRaceShort>
+  <QE_BrainScanDescription_Expertises>Stored expertises</QE_BrainScanDescription_Expertises>
 </LanguageData>

--- a/Languages/French/Keyed/QuestionableEthics.xml
+++ b/Languages/French/Keyed/QuestionableEthics.xml
@@ -120,4 +120,8 @@
   <QE_UseFillingGraphic>Visualiser le remplissage des ingrédients</QE_UseFillingGraphic>
   <QE_UseFillingGraphicTooltip>Montrer que la cuve se remplit de ressources au lieu d'être vide jusqu'à ce qu'elle soit remplie.</QE_UseFillingGraphicTooltip>
   <QE_MessageCloningFailedAnomaly>Le clonage a échoué à cause d'une séquence génomique anormale, {0} a donné naissance à un pion brisé.</QE_MessageCloningFailedAnomaly>
+  <QE_GenomeSequencerRejectExcludedHediffShort>hediff à l'exclusion du séquençage du génome</QE_GenomeSequencerRejectExcludedHediffShort>
+  <QE_BrainScanningRejectExcludedHediffShort>hediffs à l'exclusion du scanner cérébral</QE_BrainScanningRejectExcludedHediffShort>
+  <QE_TemplatingRejectExcludedRaceShort>race non valide</QE_TemplatingRejectExcludedRaceShort>
+  <QE_BrainScanDescription_Expertises>Expertises stockées</QE_BrainScanDescription_Expertises>
 </LanguageData>

--- a/Languages/German/Keyed/QuestionableEthics.xml
+++ b/Languages/German/Keyed/QuestionableEthics.xml
@@ -120,4 +120,8 @@
   <QE_UseFillingGraphic>Visualisierung der Zutatenfüllung</QE_UseFillingGraphic>
   <QE_UseFillingGraphicTooltip>Zeigen Sie weiterhin an, dass sich die Wanne mit Ressourcen füllt, anstatt leer angezeigt zu werden, bis sie gefüllt ist.</QE_UseFillingGraphicTooltip>
   <QE_MessageCloningFailedAnomaly>Das Klonen ist aufgrund einer abnormalen Genomsequenz furchtbar gescheitert, {0} wurde als gebrochener Hulk einer Spielfigur hervorgebracht</QE_MessageCloningFailedAnomaly>
+  <QE_GenomeSequencerRejectExcludedHediffShort>hediffs ohne Genomsequenzierung</QE_GenomeSequencerRejectExcludedHediffShort>
+  <QE_BrainScanningRejectExcludedHediffShort>hediffs ohne Gehirnscanning</QE_BrainScanningRejectExcludedHediffShort>
+  <QE_TemplatingRejectExcludedRaceShort>nicht gültige Ethnie</QE_TemplatingRejectExcludedRaceShort>
+  <QE_BrainScanDescription_Expertises>Gespeicherte Expertisen</QE_BrainScanDescription_Expertises>
 </LanguageData>

--- a/Languages/Japanese/Keyed/QuestionableEthics.xml
+++ b/Languages/Japanese/Keyed/QuestionableEthics.xml
@@ -137,4 +137,8 @@
   <QE_UseFillingGraphic>食材の充填を視覚化する</QE_UseFillingGraphic>
   <QE_UseFillingGraphicTooltip>桶が満杯になるまで空として表示される代わりに、桶が資源で満杯になるまで表示される。</QE_UseFillingGraphicTooltip>
   <QE_MessageCloningFailedAnomaly>ゲノム配列の異常によりクローニングに大失敗。</QE_MessageCloningFailedAnomaly>
+  <QE_GenomeSequencerRejectExcludedHediffShort>ゲノムシークエンシングを除くのヘディフ</QE_GenomeSequencerRejectExcludedHediffShort>
+  <QE_BrainScanningRejectExcludedHediffShort>脳スキャンを除くのヘディフ</QE_BrainScanningRejectExcludedHediffShort>
+  <QE_TemplatingRejectExcludedRaceShort>無効レース</QE_TemplatingRejectExcludedRaceShort>
+  <QE_BrainScanDescription_Expertises>蓄積された専門知識</QE_BrainScanDescription_Expertises>
 </LanguageData>

--- a/Languages/Russian/Keyed/QuestionableEthics.xml
+++ b/Languages/Russian/Keyed/QuestionableEthics.xml
@@ -120,4 +120,8 @@
   <QE_UseFillingGraphic>Визуализация наполнения ингредиентами</QE_UseFillingGraphic>
   <QE_UseFillingGraphicTooltip>Показывать заполнение резервуара ресурсами, а не показывать его пустым до заполнения</QE_UseFillingGraphicTooltip>
   <QE_MessageCloningFailedAnomaly>Клонирование прошло неудачно из-за аномальной последовательности генома, {0} появился на свет в виде сломанной пешки.</QE_MessageCloningFailedAnomaly>
+  <QE_GenomeSequencerRejectExcludedHediffShort>hediffs исключающие секвенирование генома</QE_GenomeSequencerRejectExcludedHediffShort>
+  <QE_BrainScanningRejectExcludedHediffShort>hediffs исключающие сканирование мозга</QE_BrainScanningRejectExcludedHediffShort>
+  <QE_TemplatingRejectExcludedRaceShort>недействительная раса</QE_TemplatingRejectExcludedRaceShort>
+  <QE_BrainScanDescription_Expertises>Накопленные знания</QE_BrainScanDescription_Expertises>
 </LanguageData>

--- a/Source/QEE/Compatibility/GeneralCompatibility.cs
+++ b/Source/QEE/Compatibility/GeneralCompatibility.cs
@@ -12,4 +12,76 @@ public static class GeneralCompatibility
     public static readonly List<HediffDef> excludedHediffs = [];
     public static readonly List<HediffDef> includedGenomeTemplateHediffs = [];
     public static readonly List<HediffDef> includedBrainTemplateHediffs = [];
+
+    public static bool IsRaceBlockingTemplateCreation(ThingDef thingDef)
+    {
+        return excludedRaces.Contains(thingDef);
+    }
+    public static bool IsBlockingBrainTemplateCreation(HediffDef hediffDef)
+    {
+        if (hediffDef.HasModExtension<HediffTemplateProperties>())
+        {
+            var hediffProp = hediffDef.GetModExtension<HediffTemplateProperties>();
+            return hediffProp.blockCreatingBrainTemplate;
+        }
+        if (excludedHediffs.Any(def => string.Equals(def.defName, hediffDef.defName)))
+        {
+            return true;
+        }
+        return false;
+    }
+
+    public static bool IsBlockingGenomeTemplateCreation(HediffDef hediffDef)
+    {
+        if (hediffDef.HasModExtension<HediffTemplateProperties>())
+        {
+            var hediffProp = hediffDef.GetModExtension<HediffTemplateProperties>();
+            return hediffProp.blockCreatingGenomeTemplate;
+        }
+        if (excludedHediffs.Any(def => string.Equals(def.defName, hediffDef.defName)))
+        {
+            return true;
+        }
+        return false;
+    }
+
+    public static bool ShouldIncludeInBrainTemplate(HediffDef hediffDef)
+    {
+        if (hediffDef.HasModExtension<HediffTemplateProperties>())
+        {
+            var hediffProp = hediffDef.GetModExtension<HediffTemplateProperties>();
+            return hediffProp.includeInBrainTemplate;
+        }
+        return includedBrainTemplateHediffs.Any(def => string.Equals(def.defName, hediffDef.defName));
+    }
+
+    public static bool ShouldIncludeInGenomeTemplate(HediffDef hediffDef)
+    {
+        if (hediffDef.HasModExtension<HediffTemplateProperties>())
+        {
+            var hediffProp = hediffDef.GetModExtension<HediffTemplateProperties>();
+            return hediffProp.includeInGenomeTemplate;
+        }
+        return includedGenomeTemplateHediffs.Any(def => string.Equals(def.defName, hediffDef.defName));
+    }
+
+    public static bool ShouldIncludeSeverityInTemplate(HediffDef hediffDef)
+    {
+        if (hediffDef.HasModExtension<HediffTemplateProperties>())
+        {
+            var hediffProp = hediffDef.GetModExtension<HediffTemplateProperties>();
+            return hediffProp.includeSeverityInTemplate;
+        }
+        return false;
+    }
+
+    public static bool ShouldKeepHediffWhenCloning(HediffDef hediffDef)
+    {
+        if (hediffDef.HasModExtension<HediffTemplateProperties>())
+        {
+            var hediffProp = hediffDef.GetModExtension<HediffTemplateProperties>();
+            return hediffProp.pregeneratedInCloning;
+        }
+        return false;
+    }
 }

--- a/Source/QEE/Compatibility/HediffTemplateProperties.cs
+++ b/Source/QEE/Compatibility/HediffTemplateProperties.cs
@@ -7,6 +7,31 @@ namespace QEthics;
 /// </summary>
 public class HediffTemplateProperties : DefModExtension
 {
+    /// <summary>
+    /// If true, when a pawn has this hediff, brain scanning cannot be done on this pawn.
+    /// </summary>
+    public readonly bool blockCreatingBrainTemplate = false;
+    /// <summary>
+    /// If true, when a pawn has this hediff, genome sequencing cannot be done on this pawn.
+    /// </summary>
+    public readonly bool blockCreatingGenomeTemplate = false;
+    /// <summary>
+    /// If true, the hediff will be record in brain template. Useful when copying mental hediffs.
+    /// </summary>
     public readonly bool includeInBrainTemplate = false;
+    /// <summary>
+    /// If true, the hediff will be record in genome template. Useful for organs and damages that need to bring forward to the clone.
+    /// </summary>
     public readonly bool includeInGenomeTemplate = false;
+    /// <summary>
+    /// If true, the severity will also be recorded. No effect if the hediff itself will not included in any of templates.
+    /// Useful if hediff has real severity and severity matters.
+    /// </summary>
+    public readonly bool includeSeverityInTemplate = false;
+    /// <summary>
+    /// If true, when a clone is generated, this pre-generated hediff is kept instead of being removed.
+    /// Useful when this organ will be added during <c>PawnGenerator.GeneratePawn</c>, but should not be bring forward via 
+    /// genome template.
+    /// </summary>
+    public readonly bool pregeneratedInCloning = false;
 }

--- a/Source/QEE/Compatibility/RaceExclusionProperties.cs
+++ b/Source/QEE/Compatibility/RaceExclusionProperties.cs
@@ -8,6 +8,16 @@ namespace QEthics;
 /// </summary>
 public class RaceExclusionProperties : DefModExtension
 {
+    /// <summary>
+    /// Listed hediffs will block creation of brain template and genome template.
+    /// Note that listed hediffs will block all races from templating, but not limited to this race.
+    /// For subtle configurating which templating shoulb be banned, 
+    /// use <see cref="HediffTemplateProperties.blockCreatingBrainTemplate"/>, or <see cref="HediffTemplateProperties.blockCreatingGenomeTemplate"/>
+    /// instead.
+    /// </summary>
     public readonly List<HediffDef> excludeTheseHediffs = [];
+    /// <summary>
+    /// If true, pawns in this race are not eligible for brain scanning and genome sequencing.
+    /// </summary>
     public readonly bool excludeThisRace = true;
 }

--- a/Source/QEE/Compatibility/VanillaSkillsExpandedCompatibility.cs
+++ b/Source/QEE/Compatibility/VanillaSkillsExpandedCompatibility.cs
@@ -1,0 +1,60 @@
+﻿using HarmonyLib;
+using System;
+using System.Linq;
+using Verse;
+using VSE;
+using VSE.Expertise;
+
+namespace QEthics
+{
+    public static class VanillaSkillsExpandedCompatibility
+    {
+        public static void GetFieldsFromVanillaSkillsExpanded(Pawn pawn, BrainScanTemplate brainScan)
+        {
+            var expertiseTracker = pawn.Expertise();
+            foreach (var expertiseRecord in expertiseTracker.AllExpertise)
+            {
+                var defName = expertiseRecord.def.defName;
+                var totalXp = expertiseRecord.XpTotalEarned;
+                brainScan.expertises.Add(new ComparableExpertiseRecord
+                {
+                    defName = defName,
+                    totalXp = totalXp,
+                });
+            }
+        }
+
+        public static void SetFieldsToVanillaSkillsExpanded(Pawn pawn, BrainScanTemplate brainScan)
+        {
+            var expertiseTracker = pawn.Expertise();
+            expertiseTracker.ClearExpertise();
+            foreach (var expertise in brainScan.expertises)
+            {
+                var def = DefDatabase<ExpertiseDef>.GetNamedSilentFail(expertise.defName);
+                if(def == null)
+                {
+                    QEEMod.TryLog($"Cannot find ExpertiseDef {expertise.defName}.");
+                    continue;
+                }
+                expertiseTracker.AddExpertise(def);
+                expertiseTracker.AllExpertise.Last().Learn(expertise.totalXp);
+            }
+        }
+
+        private static Type cachedExpertiseDefType = null;
+        private static bool? cachedExpertiseDefTypeFound = null;
+
+        public static TaggedString ExpertiseDefLabelCap(string defName)
+        {
+            if (!CompatibilityTracker.SkillsExpandedActive) return defName;
+            if (cachedExpertiseDefTypeFound == null)
+            {
+                cachedExpertiseDefType = AccessTools.TypeByName("VSE.Expertise.ExpertiseDef");
+                cachedExpertiseDefTypeFound = cachedExpertiseDefType != null;
+            }
+            if(cachedExpertiseDefType == null)
+                return defName;
+            return GenDefDatabase.GetDefSilentFail(cachedExpertiseDefType, defName)?.LabelCap ?? defName;
+        }
+    }
+}

--- a/Source/QEE/CompatibilityTracker.cs
+++ b/Source/QEE/CompatibilityTracker.cs
@@ -52,6 +52,13 @@ public static class CompatibilityTracker
                 continue;
             }
 
+            if (modName.Contains("Vanilla Skills Expanded"))
+            {
+                SkillsExpandedActive = true;
+                QEEMod.TryLog("Vanilla Skills Expanded detected");
+                continue;
+            }
+
             if (modName.Contains("Rah's Bionics and Surgery Expansion") ||
                 modName.Contains("RBSE Hardcore Edition"))
             {
@@ -85,6 +92,8 @@ public static class CompatibilityTracker
     public static bool RBSEActive { get; }
 
     public static bool AnimalGeneticsActive { get; }
+
+    public static bool SkillsExpandedActive { get; }
 
     public static FieldInfo HeadTypeField { get; }
     public static FieldInfo EyeColorField { get; }

--- a/Source/QEE/Logic/ComparableExpertiseRecord.cs
+++ b/Source/QEE/Logic/ComparableExpertiseRecord.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using Verse;
+
+namespace QEthics
+{
+    public class ComparableExpertiseRecord : IExposable, IEquatable<ComparableExpertiseRecord>
+    {
+        public string defName;
+        public float totalXp;
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null) return false;
+            if (!(obj is ComparableExpertiseRecord))
+                return false;
+            return Equals((ComparableExpertiseRecord)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return (defName.GetHashCode() * 17) + totalXp.GetHashCode();
+        }
+
+        public bool Equals(ComparableExpertiseRecord other)
+        {
+            return defName == other.defName && totalXp == other.totalXp;
+        }
+
+        public void ExposeData()
+        {
+            Scribe_Values.Look(ref defName, "defName");
+            Scribe_Values.Look(ref totalXp, "totalXp");
+        }
+
+        public override string ToString()
+        {
+            return "    " + VanillaSkillsExpandedCompatibility.ExpertiseDefLabelCap(defName) + ": " + totalXp.ToString() + " xp";
+        }
+    }
+}

--- a/Source/QEE/Logic/HediffInfo.cs
+++ b/Source/QEE/Logic/HediffInfo.cs
@@ -16,6 +16,7 @@ public class HediffInfo : IExposable, IEquatable<HediffInfo>
 {
     public HediffDef def;
     public BodyPartRecord part;
+    public float? severity;
     public List<string> psychicAwakeningPowersKnownDefNames;
 
     public bool Equals(HediffInfo other)
@@ -29,6 +30,7 @@ public class HediffInfo : IExposable, IEquatable<HediffInfo>
                 def?.defName == other.def?.defName) &&
                (part == null && other.part == null ||
                 part?.LabelCap == other.part.LabelCap) &&
+                (severity == null && other.severity == null || severity == other.severity) &&
                (psychicAwakeningPowersKnownDefNames == null && other.psychicAwakeningPowersKnownDefNames == null ||
                 psychicAwakeningPowersKnownDefNames != null && other.psychicAwakeningPowersKnownDefNames != null &&
                 psychicAwakeningPowersKnownDefNames.OrderBy(a => a)
@@ -39,6 +41,7 @@ public class HediffInfo : IExposable, IEquatable<HediffInfo>
     {
         Scribe_Defs.Look(ref def, "hediffDef");
         Scribe_BodyParts.Look(ref part, "bodyPart");
+        Scribe_Values.Look(ref severity, "severity");
         Scribe_Collections.Look(ref psychicAwakeningPowersKnownDefNames, "psychicAwakeningPowersKnownDefNames");
     }
 
@@ -48,6 +51,7 @@ public class HediffInfo : IExposable, IEquatable<HediffInfo>
         hash = (hash * 23) + (def?.GetHashCode() ?? 0);
         //the LabelCap field should be unique enough for the hash
         hash = (hash * 23) + (part?.LabelCap.GetHashCode() ?? 0);
+        hash = (hash * 23) + severity.GetHashCode();
         hash = (hash * 23) + (psychicAwakeningPowersKnownDefNames?.GetHashCode() ?? 0);
         return hash;
     }
@@ -112,10 +116,14 @@ public class HediffInfo : IExposable, IEquatable<HediffInfo>
     {
     }
 
-    public HediffInfo(Hediff h)
+    public HediffInfo(Hediff h, bool shouldRecordSeverity = false)
     {
         def = h.def;
         part = h.Part;
+        if (shouldRecordSeverity)
+        {
+            severity = h.Severity;
+        }
 
         if (!CompatibilityTracker.PsychicAwakeningActive)
         {

--- a/Source/QEE/PostDefFixer.cs
+++ b/Source/QEE/PostDefFixer.cs
@@ -64,26 +64,27 @@ public static class PostDefFixer
             }
         }
 
-        foreach (var def in DefDatabase<HediffDef>.AllDefs)
-        {
-            if (def.GetModExtension<HediffTemplateProperties>() is not { } props)
-            {
-                continue;
-            }
+        // Now will check the HediffTemplateProperties directly.
+        //foreach (var def in DefDatabase<HediffDef>.AllDefs)
+        //{
+        //    if (def.GetModExtension<HediffTemplateProperties>() is not { } props)
+        //    {
+        //        continue;
+        //    }
 
-            if (props.includeInBrainTemplate)
-            {
-                QEEMod.TryLog($"{def.defName} added to list of Hediffs applied to brain templates");
-                GeneralCompatibility.includedBrainTemplateHediffs.Add(def);
-            }
+        //    if (props.includeInBrainTemplate)
+        //    {
+        //        QEEMod.TryLog($"{def.defName} added to list of Hediffs applied to brain templates");
+        //        GeneralCompatibility.includedBrainTemplateHediffs.Add(def);
+        //    }
 
-            if (!props.includeInGenomeTemplate)
-            {
-                continue;
-            }
+        //    if (!props.includeInGenomeTemplate)
+        //    {
+        //        continue;
+        //    }
 
-            QEEMod.TryLog($"{def.defName} added to list of Hediffs applied to genome templates");
-            GeneralCompatibility.includedGenomeTemplateHediffs.Add(def);
-        }
+        //    QEEMod.TryLog($"{def.defName} added to list of Hediffs applied to genome templates");
+        //    GeneralCompatibility.includedGenomeTemplateHediffs.Add(def);
+        //}
     }
 }

--- a/Source/QEE/QEthics.csproj
+++ b/Source/QEE/QEthics.csproj
@@ -44,5 +44,10 @@
       <CopyLocal>False</CopyLocal>
       <Private>false</Private>
     </Reference>
+    <Reference Include="SkillExpanded">
+      <HintPath>..\..\..\..\..\..\workshop\content\294100\3400246558\1.5\Assemblies\VSE.dll</HintPath>
+      <CopyLocal>False</CopyLocal>
+      <Private>false</Private>
+    </Reference>
   </ItemGroup>
 </Project>

--- a/Source/QEE/Things/BrainScanTemplate.cs
+++ b/Source/QEE/Things/BrainScanTemplate.cs
@@ -33,7 +33,7 @@ public class BrainScanTemplate : ThingWithComps
     public DefMap<TrainableDef, int> trainingSteps = new DefMap<TrainableDef, int>();
 
     //VanillaSkillsExpanded compat
-    public List<ComparableExpertiseRecord> expertises = new List<ComparableExpertiseRecord>();
+    public List<ComparableExpertiseRecord> expertises = [];
 
     public override string LabelNoCount
     {
@@ -93,6 +93,8 @@ public class BrainScanTemplate : ThingWithComps
         Scribe_Deep.Look(ref trainingSteps, "trainingSteps");
         Scribe_Collections.Look(ref hediffInfos, "hediffInfos", LookMode.Deep);
         Scribe_Collections.Look(ref expertises, "expertises", LookMode.Deep);
+        // Scribe_Collections will nullify if node not found, but we expects non null
+        if (Scribe.mode == LoadSaveMode.LoadingVars && expertises == null) expertises = []; 
 
         if (Scribe.mode != LoadSaveMode.LoadingVars || hediffInfos == null)
         {

--- a/Source/QEE/Things/BrainScanTemplate.cs
+++ b/Source/QEE/Things/BrainScanTemplate.cs
@@ -32,6 +32,9 @@ public class BrainScanTemplate : ThingWithComps
     public DefMap<TrainableDef, bool> trainingLearned = new DefMap<TrainableDef, bool>();
     public DefMap<TrainableDef, int> trainingSteps = new DefMap<TrainableDef, int>();
 
+    //VanillaSkillsExpanded compat
+    public List<ComparableExpertiseRecord> expertises = new List<ComparableExpertiseRecord>();
+
     public override string LabelNoCount
     {
         get
@@ -56,7 +59,7 @@ public class BrainScanTemplate : ThingWithComps
         Scribe_Values.Look(ref sourceName, "sourceName");
         Scribe_Defs.Look(ref kindDef, "kindDef");
 
-        var childhoodIdentifier = backStoryChild?.identifier;
+        var childhoodIdentifier = backStoryChild?.defName;
         Scribe_Values.Look(ref childhoodIdentifier, "backStoryChild");
         if (Scribe.mode == LoadSaveMode.LoadingVars && !childhoodIdentifier.NullOrEmpty())
         {
@@ -70,7 +73,7 @@ public class BrainScanTemplate : ThingWithComps
             }
         }
 
-        var adulthoodIdentifier = backStoryAdult?.identifier;
+        var adulthoodIdentifier = backStoryAdult?.defName;
         Scribe_Values.Look(ref adulthoodIdentifier, "backStoryAdult");
         if (Scribe.mode == LoadSaveMode.LoadingVars && !adulthoodIdentifier.NullOrEmpty())
         {
@@ -89,6 +92,7 @@ public class BrainScanTemplate : ThingWithComps
         Scribe_Deep.Look(ref trainingLearned, "trainingLearned");
         Scribe_Deep.Look(ref trainingSteps, "trainingSteps");
         Scribe_Collections.Look(ref hediffInfos, "hediffInfos", LookMode.Deep);
+        Scribe_Collections.Look(ref expertises, "expertises", LookMode.Deep);
 
         if (Scribe.mode != LoadSaveMode.LoadingVars || hediffInfos == null)
         {
@@ -145,6 +149,15 @@ public class BrainScanTemplate : ThingWithComps
             foreach (var skill in skills.OrderBy(skillRecord => skillRecord.def.index))
             {
                 builder.AppendLine(skill.ToString());
+            }
+        }
+
+        if (expertises.Count > 0)
+        {
+            builder.AppendLine("QE_BrainScanDescription_Expertises".Translate());
+            foreach (var expertise in expertises)
+            {
+                builder.AppendLine(expertise.ToString());
             }
         }
 
@@ -227,6 +240,15 @@ public class BrainScanTemplate : ThingWithComps
             }
         }
 
+        foreach (var expertise in expertises)
+        {
+            brainScan.expertises.Add(new ComparableExpertiseRecord
+            {
+                defName = expertise.defName,
+                totalXp = expertise.totalXp
+            });
+        }
+
         //Animal
         foreach (var item in trainingLearned)
         {
@@ -257,6 +279,11 @@ public class BrainScanTemplate : ThingWithComps
                skills.SequenceEqual(other);
     }
 
+    public bool ExpertiseEqual(List<ComparableExpertiseRecord> other)
+    {
+        return expertises.Count == other.Count && expertises.SequenceEqual(other);
+    }
+
     public override bool CanStackWith(Thing other)
     {
         if (other is BrainScanTemplate brainScan &&
@@ -265,6 +292,7 @@ public class BrainScanTemplate : ThingWithComps
             DefMapsEqual(trainingLearned, brainScan.trainingLearned) &&
             DefMapsEqual(trainingSteps, brainScan.trainingSteps)
             && SkillsEqual(brainScan.skills)
+            && ExpertiseEqual(brainScan.expertises)
             && sourceName == brainScan.sourceName &&
             (kindDef?.defName != null && brainScan.kindDef?.defName != null &&
              kindDef.defName == brainScan.kindDef.defName

--- a/Source/QEE/Things/BrainScanTemplate.cs
+++ b/Source/QEE/Things/BrainScanTemplate.cs
@@ -270,7 +270,7 @@ public class BrainScanTemplate : ThingWithComps
              kindDef.defName == brainScan.kindDef.defName
              || kindDef == null && brainScan.kindDef == null) &&
             (hediffInfos != null && brainScan.hediffInfos != null &&
-             hediffInfos.OrderBy(h => h.def.LabelCap).SequenceEqual(brainScan.hediffInfos.OrderBy(h => h.def.LabelCap))
+             hediffInfos.OrderBy(h => h.def.LabelCap.ToString()).SequenceEqual(brainScan.hediffInfos.OrderBy(h => h.def.LabelCap.ToString()))
              || hediffInfos == null && brainScan.hediffInfos == null))
         {
             return base.CanStackWith(other);

--- a/Source/QEE/Things/GenomeSequence.cs
+++ b/Source/QEE/Things/GenomeSequence.cs
@@ -248,8 +248,8 @@ public class GenomeSequence : ThingWithComps
              || hair == null && otherGenome.hair == null) &&
             traits.SequenceEqual(otherGenome.traits) &&
             (hediffInfos != null && otherGenome.hediffInfos != null &&
-             hediffInfos.OrderBy(h => h.def.LabelCap)
-                 .SequenceEqual(otherGenome.hediffInfos.OrderBy(h => h.def.LabelCap))
+             hediffInfos.OrderBy(h => h.def.LabelCap.ToString())
+                 .SequenceEqual(otherGenome.hediffInfos.OrderBy(h => h.def.LabelCap.ToString()))
              || hediffInfos == null && otherGenome.hediffInfos == null) &&
             (addonVariants != null && otherGenome.addonVariants != null &&
              addonVariants.SequenceEqual(otherGenome.addonVariants)

--- a/Source/QEE/Utilities/BrainManipUtility.cs
+++ b/Source/QEE/Utilities/BrainManipUtility.cs
@@ -21,18 +21,24 @@ public static class BrainManipUtility
             GeneralCompatibility.IsBlockingBrainTemplateCreation(hediff.def));
     }
 
-    public static bool IsValidBrainScanningTarget(Pawn targetPawn, ref string failReason)
+    public static bool IsValidBrainScanningTarget(Pawn targetPawn, ref string failReason, bool inOperationTab = false)
     {
         var def = targetPawn.def;
 
         if (!IsValidBrainScanningDef(def))
         {
+            if (inOperationTab)
+            {
+                failReason = "QE_TemplatingRejectExcludedRaceShort".Translate();
+                return false;
+            }
             failReason = "QE_BrainScanningRejectExcludedRace".Translate(targetPawn.kindDef.race);
             return false;
         }
 
         if (targetPawn.Dead)
         {
+            // Corpse is not allowed to take operation. no need to check inOperationTab
             failReason = "QE_BrainScanningRejectDead".Translate(targetPawn.Named("PAWN"));
             return false;
         }
@@ -44,7 +50,14 @@ public static class BrainManipUtility
             return true;
         }
 
-        failReason = "QE_BrainScanningRejectExcludedHediff".Translate(targetPawn.Named("PAWN"));
+        if (inOperationTab)
+        {
+            failReason = "QE_BrainScanningRejectExcludedHediffShort".Translate();
+        }
+        else
+        {
+            failReason = "QE_BrainScanningRejectExcludedHediff".Translate(targetPawn.Named("PAWN"));
+        }
         return false;
     }
 

--- a/Source/QEE/Utilities/BrainManipUtility.cs
+++ b/Source/QEE/Utilities/BrainManipUtility.cs
@@ -201,6 +201,11 @@ public static class BrainManipUtility
             brainScan.hediffInfos.Add(new HediffInfo(h, GeneralCompatibility.ShouldIncludeSeverityInTemplate(h.def)));
         }
 
+        if (CompatibilityTracker.SkillsExpandedActive)
+        {
+            VanillaSkillsExpandedCompatibility.GetFieldsFromVanillaSkillsExpanded(pawn, brainScan);
+        }
+
         return brainScanThing;
     }
 
@@ -236,8 +241,8 @@ public static class BrainManipUtility
                 pawnSkill.Level = (int)Math.Floor(skill.level * efficency);
                 pawnSkill.passion = skill.passion;
             }
-            skillTracker.Notify_SkillDisablesChanged();
         }
+        thePawn.Notify_DisabledWorkTypesChanged();
 
         //Training
         var trainingTracker = thePawn.training;
@@ -313,6 +318,11 @@ public static class BrainManipUtility
 
                 PsychicAwakeningCompat.powersKnownField.SetValue(addedHediff, powers);
             }
+        }
+
+        if (CompatibilityTracker.SkillsExpandedActive)
+        {
+            VanillaSkillsExpandedCompatibility.SetFieldsToVanillaSkillsExpanded(thePawn, brainScan);
         }
 
         Find.HistoryEventsManager.RecordEvent(new HistoryEvent(QEHistoryDefOf.BrainUploaded));

--- a/Source/QEE/Utilities/GenomeUtility.cs
+++ b/Source/QEE/Utilities/GenomeUtility.cs
@@ -440,6 +440,23 @@ public static class GenomeUtility
             GeneralCompatibility.IsBlockingGenomeTemplateCreation(hediff.def));
     }
 
+    public static bool IsValidGenomeSequencingTarget(Pawn pawn, ref string failReason)
+    {
+        // Currently only used in Operation tab. Short reason is sufficient.
+        if (!IsValidGenomeSequencingTargetDef(pawn.def))
+        {
+            failReason = "QE_TemplatingRejectExcludedRaceShort".Translate();
+            return false;
+        }
+        if(!pawn.health.hediffSet.hediffs.Any(hediff =>
+            GeneralCompatibility.IsBlockingGenomeTemplateCreation(hediff.def)))
+        {
+            return true;
+        }
+        failReason = "QE_GenomeSequencerRejectExcludedHediffShort".Translate();
+        return false;
+    }
+
     public static void TryFixSequenceGenes(GenomeSequence genomeSequence)
     {
         if (genomeSequence == null) return;

--- a/Source/QEE/Workers/RecipeWorker_CreateBrainScan.cs
+++ b/Source/QEE/Workers/RecipeWorker_CreateBrainScan.cs
@@ -7,12 +7,27 @@ namespace QEthics;
 
 public class RecipeWorker_CreateBrainScan : RecipeWorker
 {
-    public override IEnumerable<BodyPartRecord> GetPartsToApplyOn(Pawn pawn, RecipeDef recipe)
+    //public override IEnumerable<BodyPartRecord> GetPartsToApplyOn(Pawn pawn, RecipeDef recipe)
+    //{
+    //    if (pawn.IsValidBrainScanningTarget())
+    //    {
+    //        QEEMod.TryLog($"Pawn {pawn.Name?.ToStringSafe() ?? pawn.LabelCap} is valid brain scanning target");
+    //        yield return null;
+    //    }
+    //    else
+    //    {
+    //        QEEMod.TryLog($"Pawn {pawn.Name?.ToStringSafe() ?? pawn.LabelCap} is not valid brain scanning target");
+    //    }
+    //}
+
+    public override AcceptanceReport AvailableReport(Thing thing, BodyPartRecord part = null)
     {
-        if (pawn.IsValidBrainScanningTarget())
+        string reason = "";
+        if(thing is Pawn pawn && BrainManipUtility.IsValidBrainScanningTarget(pawn, ref reason, true))
         {
-            yield return null;
+            return true;
         }
+        return reason;
     }
 
     public override void ApplyOnPawn(Pawn pawn, BodyPartRecord part, Pawn billDoer, List<Thing> ingredients, Bill bill)

--- a/Source/QEE/Workers/RecipeWorker_GenomeSequencing.cs
+++ b/Source/QEE/Workers/RecipeWorker_GenomeSequencing.cs
@@ -7,12 +7,22 @@ namespace QEthics;
 
 public class RecipeWorker_GenomeSequencing : RecipeWorker
 {
-    public override IEnumerable<BodyPartRecord> GetPartsToApplyOn(Pawn pawn, RecipeDef recipe)
+    //public override IEnumerable<BodyPartRecord> GetPartsToApplyOn(Pawn pawn, RecipeDef recipe)
+    //{
+    //    if (pawn.IsValidGenomeSequencingTarget())
+    //    {
+    //        yield return null;
+    //    }
+    //}
+
+    public override AcceptanceReport AvailableReport(Thing thing, BodyPartRecord part = null)
     {
-        if (pawn.IsValidGenomeSequencingTarget())
+        string reason = "";
+        if(thing is Pawn pawn && GenomeUtility.IsValidGenomeSequencingTarget(pawn, ref reason))
         {
-            yield return null;
+            return true;
         }
+        return reason;
     }
 
     public override void ApplyOnPawn(Pawn pawn, BodyPartRecord part, Pawn billDoer, List<Thing> ingredients, Bill bill)


### PR DESCRIPTION
More compatibilities with other mods, and some revamps on GeneralCompatibility for brain template and genome template.

## New features (User)
1. When genome sequence and brain scanner is in storage, genome sequencing and brain scanning operation will always be shown in "add surgery" now. These operations will be disabled will disabled reason appended on the labels if invalid races or hediffs blocking such operation.
2. When Vanilla Skills Expanded is installed, brain scanner will also store pawn's expertise.

## New features (Developer)
1. Add `blockCreatingBrainTemplate` and `blockCreatingGenomeTemplate` for `HediffTemplateProperties`, allowing modders to block brain scanning or genome sequencing separately.
4. Add `includeSeverityInTemplate` for `HediffTemplateProperties`, allowing modders to request templates to record severity of hediff if severity matters.
5. Add `pregeneratedInCloning` for `HediffTemplateProperties`, allowing modders to request cloning vat to keep the pregenerated hediff from being flushed out, but such hediff should not be recorded in templates. For example, a mod that add a gene which will create a special organ. Such organ can be replaced with artificial part and the modder decides that that artificial organ should not be grown with the clone, but instead the natural organ from the gene.

## Fixes
1. Fix brain scanning template not saving backstories into game save.
2. Fix genome sequencing and brain scanning operations not showing up even when the corresponding item exists in storage,  when Alpha Implants is loaded before QEE.

## Other changes
1. Add some documentation for `HediffTemplateProperties` and `RaceExclusionProperties`.
2. Wrap checking code related to `GeneralCompatibility` into methods, moved into `GeneralCompatibility`. Now such checking will primarily use values in `HediffTemplateProperties`.

EDIT (22 Feb 2025): Added New features # 1, # 2. Added Fixes # 1.