### PR TITLE
fix failed to make pawn in clone vat if biotech is NOT active

### DIFF
--- a/Source/QEE/Utilities/GenomeUtility.cs
+++ b/Source/QEE/Utilities/GenomeUtility.cs
@@ -263,12 +263,16 @@ public static class GenomeUtility
         pawn?.health.hediffSet.DirtyCache();
         pawn?.health.CheckForStateChange(null, null);
 
-        if (pawn?.genes is { } geneTracker)
+        // If biotech is not installed, nothing inside this will be made actions.
+        if (ModLister.BiotechInstalled && pawn?.genes is { } geneTracker)
         {
             // restore those being trimmed for pawn generation
-            geneTracker.xenotype.doubleXenotypeChances = oldXenotypeDoubleChance;
-            geneTracker.xenotype.genes = oldXenotypeGenes;
-            geneTracker.xenotype.generateWithXenogermReplicatingHediffChance = oldGenerateWithXenogermHediffChance;
+            if(geneTracker.xenotype != null)
+            {
+                geneTracker.xenotype.doubleXenotypeChances = oldXenotypeDoubleChance;
+                geneTracker.xenotype.genes = oldXenotypeGenes;
+                geneTracker.xenotype.generateWithXenogermReplicatingHediffChance = oldGenerateWithXenogermHediffChance;
+            }
             if (genomeSequence.activeRandomlyChosenEndogenes?.Any() ?? false)
             {
                 foreach (var activeGeneDef in genomeSequence.activeRandomlyChosenEndogenes)


### PR DESCRIPTION
When implementing fixes towards Biotech support, a null check on xenotype is missing which creates spamming NullReferenceException whenever the clone vat trying to make a new pawn if Biotech is not active. If biotech is not active, xenotype of a pawn is always be null, which causes error.
This pr patches this issue. My bad for missing this null check and creating game blocking bug :(.

Side note: If anyone has QEE and EvolvedOrganRedux installed, and chose the EvolvedOrgan's implant to be made in QEE's Organ Vat, red errors will be spammed and blocking all actions in the room with Organ Vat installed. This is a bug from EvolvedOrganRedux side where they somehow removed reptilian frontal cortex (EVOR_Item_Brain_ReptilianFrontalCortex) in RimWorld 1.5, but the patch to allow Organ Vat to make this is not removed. This mistake will first pops a red error at title menu, complaining the product def of this recipe points to nothing. Then red errors start to spam when calculating room score of the room with Organ Vat. This bug has to be fixed in EvolvedOrganRedux side. At the time being, players are advised to use EvolvedOragnRedux's workbench to create their implants.